### PR TITLE
feat(admin): members list pagination + region filter; fix rewrites to europe-west1; re‑enable admin activate E2E

### DIFF
--- a/docs/NEXT_TASKS.md
+++ b/docs/NEXT_TASKS.md
@@ -1,0 +1,65 @@
+# NEXT TASKS — Bulletproof Membership Card System
+
+Branch: feat/phase-2
+
+Legend: [ ] TODO • [~] In Progress • [x] Done • (P1/P2/P3) Priority
+
+## Phase 0 — Stabilize & Baseline
+- [ ] (P1) Re‑enable admin_activate E2E with backend verification only
+- [ ] (P1) Admin members list: add cursor‑based pagination + region filters
+- [ ] (P2) Run nameLower backfill to completion (via Admin dialog) and note final state
+- [ ] (P2) TTL/cleanup plan for `audit_logs` (>180 days) and `metrics` rollups
+
+## Phase 1 — Self‑Renewal & Payments
+- [ ] (P1) Add Stripe Checkout/Payment Element on Billing/Profile (attach `metadata.uid`)
+- [ ] (P1) Webhook mapping: `invoice.payment_succeeded` → `startMembership` (idempotent)
+- [ ] (P1) Renewal UX: expired/renew CTAs; success page/card re‑send; emails/receipts
+- [ ] (P2) Admin renewals: one‑click renew; bulk renew (table selection / CSV)
+
+## Phase 2 — Card Security & Robustness
+- [ ] (P1) Signed QR tokens (JWT with `memberNo`, `exp`, `kid`); verify validates signature + active state
+- [ ] (P2) Public verify privacy: minimal response; prod rate‑limit (Cloud Armor / captcha option)
+- [ ] (P2) Revocation/rotation: versioned keys + revocation list
+- [ ] (P3) Optional offline card cache (no PII), prompt re‑verify near expiration
+
+## Phase 3 — Exports, Reporting, Admin Scale
+- [ ] (P1) Async CSV export: write to Storage, email signed URL; UI status/progress
+- [ ] (P2) Dashboard metrics: expiring next 30 days, active by region/org, renewals trend (simple charts)
+- [ ] (P2) Advanced filters: region, status, expiring windows; (P3) full‑text via search service if needed
+
+## Phase 4 — Storage & Attachments (Optional)
+- [ ] (P2) Storage rules for attachments (owner/admin/agent by region); deny public
+- [ ] (P2) Malware scan on upload; quarantine + logs
+- [ ] (P3) Retention policy for attachments
+
+## Phase 5 — Security & Compliance
+- [ ] (P1) Rules review: ensure `adminHasRegion`/`agentHasRegion` used across all paths; deny defaults
+- [ ] (P1) Secrets: verify Stripe keys in Functions secrets; rotation notes
+- [ ] (P2) Audit completeness: all mutating actions logged with actor/target/ts; TTL plan
+- [ ] (P2) GDPR/data lifecycle: exports deletion policy; member deletion flow tested
+
+## Phase 6 — Performance & Scale
+- [ ] (P1) Sharded `members-<year>` counters or pre‑allocated ranges for memberNo to avoid hotspots
+- [ ] (P2) Indexes for admin filters; ensure all list views page (limit+cursor) and no N+1 reads
+- [ ] (P3) Load tests: verify bursts, renewal spikes, export queues; observe latency/error budgets
+
+## Phase 7 — Observability & Ops
+- [ ] (P2) Structured logs for key actions; reduce noise
+- [ ] (P2) Metrics & alerts: webhook failures, verify latency, renewals/day; SLOs + alerting
+- [ ] (P2) Runbooks for webhook/export/rules/key rotation incidents
+- [ ] (P3) Backups: scheduled Firestore exports; tested restore
+
+## Phase 8 — CI/CD & Developer Experience
+- [ ] (P1) Re‑enable full CI (functions/rules/E2E) once billing fixed; cache emulator deps; upload coverage
+- [ ] (P2) PR previews on Hosting; optional staging project for smoke tests
+- [ ] (P2) Deterministic seeding & fixtures for E2E; flaky test detector
+
+## Phase 9 — UX & Accessibility
+- [ ] (P2) A11y: focus traps, keyboard nav, contrast for badges
+- [ ] (P3) i18n scaffold (if needed)
+- [ ] (P2) Mobile: card readability across common devices
+
+---
+
+Owners: assign per task in PRs. Update progress with [ ] → [~] → [x].
+

--- a/docs/NEXT_TASKS.md
+++ b/docs/NEXT_TASKS.md
@@ -5,8 +5,8 @@ Branch: feat/phase-2
 Legend: [ ] TODO • [~] In Progress • [x] Done • (P1/P2/P3) Priority
 
 ## Phase 0 — Stabilize & Baseline
-- [ ] (P1) Re‑enable admin_activate E2E with backend verification only
-- [ ] (P1) Admin members list: add cursor‑based pagination + region filters
+- [x] (P1) Re‑enable admin_activate E2E with backend verification only
+- [x] (P1) Admin members list: add cursor‑based pagination + region filters
 - [ ] (P2) Run nameLower backfill to completion (via Admin dialog) and note final state
 - [ ] (P2) TTL/cleanup plan for `audit_logs` (>180 days) and `metrics` rollups
 
@@ -62,4 +62,3 @@ Legend: [ ] TODO • [~] In Progress • [x] Done • (P1/P2/P3) Priority
 ---
 
 Owners: assign per task in PRs. Update progress with [ ] → [~] → [x].
-

--- a/docs/STATE_SNAPSHOT_2025-09-08.md
+++ b/docs/STATE_SNAPSHOT_2025-09-08.md
@@ -34,3 +34,18 @@ End-of-session snapshot (to be appended)
   - Rate limiting for verifyMembership (per-IP 60/min, 1000/day; emulator bypassed).
   - Audit logs on setUserRole and startMembership.
   - Admin UI: Role Management (lookup by email, set role, select allowed regions).
+
+---
+
+End-of-day snapshot
+- Timestamp (UTC): 2025-09-08T21:00:24Z
+- Branch: feat/phase-2
+- Commit: db63a136
+- Changes summary:
+  - Admin search: email, memberNo, and name prefix via nameLower.
+  - Writers populate nameLower; added backfillNameLower callable + Admin backfill dialog (start/stop/resume).
+  - Profile card shows ACTIVE using summary expiresAt; Download QR now works (canvas fallback).
+  - Bulk import (CSV) UI + callable (dry-run/import) with error reporting.
+  - Audit Logs panel and Daily Metrics panel in Admin.
+  - Stripe webhook signature verification + idempotency (earlier today), startMembership Timestamp fix.
+  - Firestore rules hardened to avoid null list errors for allowedRegions.

--- a/docs/STATE_SNAPSHOT_2025-09-08.md
+++ b/docs/STATE_SNAPSHOT_2025-09-08.md
@@ -49,3 +49,14 @@ End-of-day snapshot
   - Audit Logs panel and Daily Metrics panel in Admin.
   - Stripe webhook signature verification + idempotency (earlier today), startMembership Timestamp fix.
   - Firestore rules hardened to avoid null list errors for allowedRegions.
+
+---
+
+2025-09-09 — Session Snapshot
+- Timestamp (UTC): $(date -u +%FT%TZ)
+- Branch: feat/phase-2
+- Commit: 0fb1aa9c
+- Changes summary:
+  - Re-enabled Admin Activate E2E with backend verification (no HTTP status intercepts).
+  - Admin members list: added cursor-based pagination (Prev/Next) and region filter (uses createdAt desc ordering; respects allowedRegions).
+  - Hosting rewrites fixed to route HTTP functions to europe-west1 (verifyMembership, stripeWebhook, exportMembersCsv).

--- a/firebase.json
+++ b/firebase.json
@@ -64,11 +64,11 @@
     "rewrites": [
       {
         "source": "/verifyMembership",
-        "function": "verifyMembership"
+        "function": { "functionId": "verifyMembership", "region": "europe-west1" }
       },
       {
         "source": "/stripeWebhook",
-        "function": "stripeWebhook"
+        "function": { "functionId": "stripeWebhook", "region": "europe-west1" }
       },
       {
         "source": "/exportMembersCsv",

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,10 +7,17 @@ service cloud.firestore {
     function isAdmin() { return hasToken() && request.auth.token.role == 'admin'; }
     function isAgent() { return hasToken() && request.auth.token.role == 'agent'; }
     function isSelf(uid) { return signedIn() && request.auth.uid == uid; }
+    function adminHasRegion(region) {
+      // Admins: if allowedRegions not present as a list, treat as full access; otherwise enforce list
+      return isAdmin() && (
+        !(request.auth.token.allowedRegions is list) ||
+        (region in request.auth.token.allowedRegions)
+      );
+    }
     function agentHasRegion(region) {
-      return isAgent() &&
-        hasToken() && request.auth.token.allowedRegions is list &&
-        region in request.auth.token.allowedRegions;
+      // Agents must have an allowedRegions list and the region must be in it
+      return isAgent() && (request.auth.token.allowedRegions is list) &&
+        (region in request.auth.token.allowedRegions);
     }
 
     match /users/{uid} {
@@ -19,22 +26,22 @@ service cloud.firestore {
     }
 
     match /members/{uid} {
-      // Read self; agents/admins limited to allowedRegions
+      // Read self; agents/admins limited by region. Admin without allowedRegions list → full access
       allow read: if isSelf(uid)
-        || (isAdmin() && resource.data.region in request.auth.token.allowedRegions)
-        || (isAgent() && resource.data.region in request.auth.token.allowedRegions);
+        || adminHasRegion(resource.data.region)
+        || agentHasRegion(resource.data.region);
       // split create into separate rules to avoid evaluating agent clause for self-writes
       allow create: if isSelf(uid);
       // Agents cannot create member docs directly (must use backend callable)
-      // Admins can create/update only within allowedRegions
-      allow create: if isAdmin() && request.auth.token.allowedRegions is list && request.resource.data.region in request.auth.token.allowedRegions;
+      // Admins can create/update only within allowedRegions (or full access if claim not set as list)
+      allow create: if adminHasRegion(request.resource.data.region);
       // split update similarly
-      allow update: if isAdmin() && resource.data.region in request.auth.token.allowedRegions;
+      allow update: if adminHasRegion(resource.data.region);
       // Members can only edit a safe subset of fields
       allow update: if isSelf(uid) &&
         request.resource.data.diff(resource.data).changedKeys().hasOnly(["name","region","phone","orgId"]);
       // Agents can edit the same safe subset within their allowed regions
-      allow update: if isAgent() && request.auth.token.allowedRegions is list && resource.data.region in request.auth.token.allowedRegions &&
+      allow update: if agentHasRegion(resource.data.region) &&
         request.resource.data.diff(resource.data).changedKeys().hasOnly(["name","region","phone","orgId"]);
       allow delete: if isAdmin();
     }

--- a/frontend/src/components/SimpleQr.tsx
+++ b/frontend/src/components/SimpleQr.tsx
@@ -1,8 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, forwardRef } from 'react';
 
 type Props = { value: string; size?: number; className?: string };
 
-export default function SimpleQr({ value, size = 128, className }: Props) {
+const SimpleQr = forwardRef<HTMLImageElement, Props>(function SimpleQr({ value, size = 128, className }, ref) {
   const primary = useMemo(
     () => `https://chart.googleapis.com/chart?cht=qr&chs=${size}x${size}&chl=${encodeURIComponent(value)}`,
     [value, size]
@@ -14,15 +14,19 @@ export default function SimpleQr({ value, size = 128, className }: Props) {
   const [src, setSrc] = useState(primary);
   return (
     <img
+      ref={ref}
       src={src}
       width={size}
       height={size}
       alt="QR code"
       className={className}
+      crossOrigin="anonymous"
       referrerPolicy="no-referrer"
       onError={() => {
         if (src !== fallback) setSrc(fallback);
       }}
     />
   );
-}
+});
+
+export default SimpleQr;

--- a/frontend/src/hooks/useAuditLogs.ts
+++ b/frontend/src/hooks/useAuditLogs.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { collection, getDocs, limit, orderBy, query, Timestamp } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export type AuditLog = {
+  id: string;
+  action: string;
+  actor?: string;
+  target?: string;
+  role?: string;
+  allowedRegions?: string[];
+  year?: number;
+  amount?: number;
+  currency?: string;
+  method?: string;
+  ts?: Timestamp;
+};
+
+export function useAuditLogs(max = 20) {
+  const [items, setItems] = useState<AuditLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const q = query(collection(db, 'audit_logs'), orderBy('ts', 'desc'), limit(max));
+        const snap = await getDocs(q);
+        if (cancelled) return;
+        const arr: AuditLog[] = snap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<AuditLog, 'id'>) }));
+        setItems(arr);
+        setError(null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [max]);
+
+  return { items, loading, error };
+}
+
+export default useAuditLogs;
+

--- a/frontend/src/hooks/useMemberSearch.ts
+++ b/frontend/src/hooks/useMemberSearch.ts
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { collection, getDocs, query, where } from 'firebase/firestore';
+import { db } from '../firebase';
+import type { Profile } from '../types';
+
+function isMemberNo(s: string) {
+  return /^INT-\d{4}-\d{6}$/i.test(s.trim());
+}
+
+export function useMemberSearch() {
+  const [results, setResults] = useState<Profile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function search(input: string) {
+    const term = input.trim();
+    if (!term) { setResults([]); setError(null); return; }
+    setLoading(true); setError(null);
+    try {
+      let qRef;
+      if (term.includes('@')) {
+        // Email exact match; store lowercased email in members
+        qRef = query(collection(db, 'members'), where('email', '==', term.toLowerCase()));
+      } else if (isMemberNo(term)) {
+        qRef = query(collection(db, 'members'), where('memberNo', '==', term.toUpperCase()));
+      } else {
+        // Fallback: try exact name match (best-effort)
+        qRef = query(collection(db, 'members'), where('name', '==', term));
+      }
+      const snap = await getDocs(qRef);
+      const items: Profile[] = snap.docs.map(d => ({ id: d.id, ...(d.data() as Profile) }));
+      setResults(items);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function clear() { setResults([]); setError(null); }
+
+  return { results, loading, error, search, clear };
+}
+
+export default useMemberSearch;
+

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -9,7 +9,7 @@ export const useUsers = (opts?: { allowedRegions?: string[]; limit?: number }) =
   const [error, setError] = useState<Error | null>(null);
   const [refreshSeq, setRefreshSeq] = useState(0);
   const allowedRegionsInput = opts?.allowedRegions ?? [];
-  const allowedRegions = useMemo(() => allowedRegionsInput, [opts?.allowedRegions && JSON.stringify(opts.allowedRegions)]);
+  const allowedRegions = useMemo(() => allowedRegionsInput, [allowedRegionsInput.join('|')]);
   const max = opts?.limit ?? 100;
 
   const regionsKey = JSON.stringify(allowedRegions);

--- a/frontend/src/hooks/useUsers.ts
+++ b/frontend/src/hooks/useUsers.ts
@@ -1,33 +1,53 @@
 import { useState, useEffect, useMemo } from 'react';
-import { collection, query, getDocs, where, limit as qLimit } from 'firebase/firestore';
+import { collection, query, getDocs, where, limit as qLimit, orderBy, startAfter } from 'firebase/firestore';
+import type { QueryConstraint, DocumentData, QueryDocumentSnapshot } from 'firebase/firestore';
 import { db } from '../firebase';
 import type { Profile } from '../types';
 
-export const useUsers = (opts?: { allowedRegions?: string[]; limit?: number }) => {
+export const useUsers = (opts?: { allowedRegions?: string[]; limit?: number; region?: string | null }) => {
   const [users, setUsers] = useState<Profile[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const [refreshSeq, setRefreshSeq] = useState(0);
+  const [page, setPage] = useState(1);
+  const [hasNext, setHasNext] = useState(false);
+  const [hasPrev, setHasPrev] = useState(false);
+  const [cursors, setCursors] = useState<QueryDocumentSnapshot<DocumentData>[]>([]);
   const allowedRegionsInput = opts?.allowedRegions ?? [];
   const allowedRegions = useMemo(() => allowedRegionsInput, [allowedRegionsInput.join('|')]);
   const max = opts?.limit ?? 100;
+  const regionFilter = opts?.region ?? null; // null => no explicit filter
 
   const regionsKey = JSON.stringify(allowedRegions);
+  const regionKey = regionFilter || 'ALL';
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
         setLoading(true);
         const usersCollectionRef = collection(db, 'members');
-        let qRef = query(usersCollectionRef, qLimit(max));
-        if (Array.isArray(allowedRegions) && allowedRegions.length > 0) {
-          // Firestore 'in' supports up to 10 values
-          qRef = query(usersCollectionRef, where('region', 'in', allowedRegions.slice(0, 10)), qLimit(max));
+        const constraints: QueryConstraint[] = [];
+        // Preferred sort for stable pagination
+        constraints.push(orderBy('createdAt', 'desc'));
+        // Region selection: if a specific region is chosen, use equality filter.
+        if (regionFilter && regionFilter !== 'ALL') {
+          constraints.push(where('region', '==', regionFilter));
+        } else if (Array.isArray(allowedRegions) && allowedRegions.length > 0) {
+          // Viewer is restricted to specific regions (agent/admin with limited regions)
+          constraints.push(where('region', 'in', allowedRegions.slice(0, 10)));
         }
+        constraints.push(qLimit(max + 1)); // fetch one extra to detect next page
+        const qRef = query(usersCollectionRef, ...constraints);
         const snap = await getDocs(qRef);
         if (cancelled) return;
-        const usersData: Profile[] = snap.docs.map(d => ({ id: d.id, ...(d.data() as Profile) }));
+        const docs = snap.docs;
+        const pageDocs = docs.slice(0, Math.min(docs.length, max));
+        const usersData: Profile[] = pageDocs.map(d => ({ id: d.id, ...(d.data() as Profile) }));
         setUsers(usersData);
+        setHasNext(docs.length > max);
+        setHasPrev(false);
+        setPage(1);
+        setCursors(pageDocs.length > 0 ? [pageDocs[pageDocs.length - 1]] : []);
         setError(null);
       } catch (err) {
         if (!cancelled) setError(err as Error);
@@ -36,9 +56,80 @@ export const useUsers = (opts?: { allowedRegions?: string[]; limit?: number }) =
       }
     })();
     return () => { cancelled = true; };
-  }, [refreshSeq, regionsKey, max, allowedRegions]);
+  }, [refreshSeq, regionsKey, regionKey, max, allowedRegions, regionFilter]);
 
   const refresh = () => setRefreshSeq((n) => n + 1);
 
-  return { users, loading, error, refresh };
+  const nextPage = async () => {
+    try {
+      setLoading(true);
+      const usersCollectionRef = collection(db, 'members');
+      const constraints: QueryConstraint[] = [orderBy('createdAt', 'desc')];
+      if (regionFilter && regionFilter !== 'ALL') {
+        constraints.push(where('region', '==', regionFilter));
+      } else if (Array.isArray(allowedRegions) && allowedRegions.length > 0) {
+        constraints.push(where('region', 'in', allowedRegions.slice(0, 10)));
+      }
+      if (cursors.length > 0) {
+        constraints.push(startAfter(cursors[cursors.length - 1]));
+      }
+      constraints.push(qLimit(max + 1));
+      const qRef = query(usersCollectionRef, ...constraints);
+      const snap = await getDocs(qRef);
+      const docs = snap.docs;
+      const pageDocs = docs.slice(0, Math.min(docs.length, max));
+      const usersData: Profile[] = pageDocs.map(d => ({ id: d.id, ...(d.data() as Profile) }));
+      setUsers(usersData);
+      setHasNext(docs.length > max);
+      // Track cursor as the last doc of the previous page for prev navigation
+      if (pageDocs.length > 0) {
+        setCursors(prev => [...prev, pageDocs[pageDocs.length - 1]]);
+        setHasPrev(true);
+        setPage(p => p + 1);
+      } else {
+        setHasPrev(cursors.length > 0);
+      }
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const prevPage = async () => {
+    try {
+      if (cursors.length === 0) return; // already at first page
+      setLoading(true);
+      const usersCollectionRef = collection(db, 'members');
+      const constraints: QueryConstraint[] = [orderBy('createdAt', 'desc')];
+      if (regionFilter && regionFilter !== 'ALL') {
+        constraints.push(where('region', '==', regionFilter));
+      } else if (Array.isArray(allowedRegions) && allowedRegions.length > 0) {
+        constraints.push(where('region', 'in', allowedRegions.slice(0, 10)));
+      }
+      // To go back, drop the last cursor and use the new last as startAfter baseline.
+      const newStack = cursors.slice(0, -1);
+      const startCursor = newStack[newStack.length - 1];
+      if (startCursor) {
+        constraints.push(startAfter(startCursor));
+      }
+      constraints.push(qLimit(max + 1));
+      const qRef = query(usersCollectionRef, ...constraints);
+      const snap = await getDocs(qRef);
+      const docs = snap.docs;
+      const pageDocs = docs.slice(0, Math.min(docs.length, max));
+      const usersData: Profile[] = pageDocs.map(d => ({ id: d.id, ...(d.data() as Profile) }));
+      setUsers(usersData);
+      setHasNext(docs.length > max);
+      setCursors(newStack);
+      setHasPrev(newStack.length > 0);
+      setPage(p => Math.max(1, p - 1));
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { users, loading, error, refresh, nextPage, prevPage, hasNext, hasPrev, page };
 };

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -18,7 +18,8 @@ import AgentRegistrationCard from '../components/AgentRegistrationCard';
 export default function Admin() {
   const { isAdmin, loading: adminLoading } = useAdmin();
   const { canRegister, allowedRegions, loading: roleLoading } = useAgentOrAdmin();
-  const { users, loading: usersLoading, error: usersError, refresh } = useUsers({ allowedRegions });
+  const [regionFilter, setRegionFilter] = useState<string>('ALL');
+  const { users, loading: usersLoading, error: usersError, refresh, nextPage, prevPage, hasNext, hasPrev, page } = useUsers({ allowedRegions, limit: 25, region: regionFilter });
   const [selectedUser, setSelectedUser] = useState<Profile | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [success, setSuccess] = useState<string | null>(null);
@@ -322,7 +323,7 @@ export default function Admin() {
               let updated = bfUpdated;
               // Loop until finished or cancel requested
               while (!bfCancel) {
-                const payload: any = { pageSize: 500 };
+                const payload: { pageSize?: number; startAfter?: string } = { pageSize: 500 };
                 if (next) payload.startAfter = next;
                 const r = await fn(payload);
                 const d = r.data;
@@ -399,6 +400,20 @@ export default function Admin() {
 
       {isAdmin && (
       <div className="bg-white shadow-md rounded-lg overflow-hidden">
+        <div className="flex items-end justify-between p-4 border-b bg-gray-50">
+          <div>
+            <label className="block text-xs font-semibold text-gray-600 uppercase">Region filter</label>
+            <select className="mt-1 border rounded px-3 py-2" value={regionFilter} onChange={(e)=> setRegionFilter(e.target.value)}>
+              <option value="ALL">All regions</option>
+              {REGIONS.map(r => (<option key={r} value={r}>{r}</option>))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <button className="px-3 py-2 bg-gray-200 rounded disabled:opacity-50" onClick={prevPage} disabled={!hasPrev}>Prev</button>
+            <div className="text-sm text-gray-700">Page {page}</div>
+            <button className="px-3 py-2 bg-gray-200 rounded disabled:opacity-50" onClick={nextPage} disabled={!hasNext}>Next</button>
+          </div>
+        </div>
         <table className="min-w-full leading-normal">
           <thead>
             <tr>

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -288,6 +288,28 @@ export default function Admin() {
 
       {isAdmin && (
         <div className="mb-6 p-4 border rounded bg-white">
+          <h3 className="text-lg font-semibold mb-2">Maintenance</h3>
+          <p className="text-sm text-gray-600 mb-2">One-off tasks for admins. These run against the current project.</p>
+          <div className="flex gap-2">
+            <button className="bg-gray-700 text-white px-3 py-2 rounded" onClick={async ()=>{
+              if (!confirm('Backfill nameLower for up to 500 members starting at the beginning?')) return;
+              try {
+                const fn = httpsCallable<{ pageSize?: number; startAfter?: string }, { page:number; updated:number; nextStartAfter:string|null }>(functions, 'backfillNameLower');
+                const r = await fn({ pageSize: 500 });
+                const data = r.data;
+                handleSuccess(`Backfill done: page=${data.page}, updated=${data.updated}${data.nextStartAfter?`, nextStartAfter=\"${data.nextStartAfter}\"`:''}`);
+              } catch (e) {
+                const msg = e instanceof Error ? e.message : String(e);
+                setError(msg);
+              }
+            }}>Backfill nameLower (500)</button>
+          </div>
+          <p className="text-xs text-gray-500 mt-2">Repeat until nextStartAfter is null to complete backfill for all members.</p>
+        </div>
+      )}
+
+      {isAdmin && (
+        <div className="mb-6 p-4 border rounded bg-white">
           <h3 className="text-lg font-semibold mb-2">Recent Audit Logs</h3>
           {auditLoading && <div className="text-gray-600">Loading…</div>}
           {auditError && <div className="text-red-600">Failed to load audit logs: {auditError.message}</div>}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -150,13 +150,18 @@ export default function Profile() {
             const expiresAtSec = activeMembership?.expiresAt?.seconds ?? (profile as any)?.expiresAt?.seconds;
             const hasActive = typeof expiresAtSec === 'number' && expiresAtSec * 1000 > Date.now();
             const validUntil = typeof expiresAtSec === 'number' ? new Date(expiresAtSec * 1000).toLocaleDateString() : '—';
+            const status = hasActive ? 'active' : (typeof expiresAtSec === 'number' ? 'expired' : 'none');
+            const memberNo = profile.memberNo || '—';
+            const verifyUrl = memberNo && memberNo !== '—' ? `${location.origin}/verify?memberNo=${encodeURIComponent(memberNo)}` : undefined;
             if (hasActive) {
               return (
                 <DigitalMembershipCard
                   name={profile.name || 'Member'}
-                  memberNo={profile.memberNo || '—'}
+                  memberNo={memberNo}
                   region={profile.region || '—'}
                   validUntil={validUntil}
+                  status={status}
+                  verifyUrl={verifyUrl}
                 />
               );
             }

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -141,18 +141,31 @@ export default function Profile() {
         </div>
         <div className="md:col-span-1">
           <h2 className="text-2xl font-bold mb-4">Membership Card</h2>
-          {profile && activeMembership ? (
-            <DigitalMembershipCard 
-              name={profile.name || 'Member'}
-              memberNo={profile.memberNo || '—'}
-              region={profile.region || '—'}
-              validUntil={activeMembership.expiresAt ? new Date(activeMembership.expiresAt.seconds * 1000).toLocaleDateString() : '—'}
-            />
-          ) : (
-            <div className="bg-gray-100 rounded-2xl p-6 text-center text-gray-500">
-              <p>No active membership found.</p>
-            </div>
-          )}
+          {(() => {
+            if (!profile) return (
+              <div className="bg-gray-100 rounded-2xl p-6 text-center text-gray-500">
+                <p>No active membership found.</p>
+              </div>
+            );
+            const expiresAtSec = activeMembership?.expiresAt?.seconds ?? (profile as any)?.expiresAt?.seconds;
+            const hasActive = typeof expiresAtSec === 'number' && expiresAtSec * 1000 > Date.now();
+            const validUntil = typeof expiresAtSec === 'number' ? new Date(expiresAtSec * 1000).toLocaleDateString() : '—';
+            if (hasActive) {
+              return (
+                <DigitalMembershipCard
+                  name={profile.name || 'Member'}
+                  memberNo={profile.memberNo || '—'}
+                  region={profile.region || '—'}
+                  validUntil={validUntil}
+                />
+              );
+            }
+            return (
+              <div className="bg-gray-100 rounded-2xl p-6 text-center text-gray-500">
+                <p>No active membership found.</p>
+              </div>
+            );
+          })()}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -147,7 +147,9 @@ export default function Profile() {
                 <p>No active membership found.</p>
               </div>
             );
-            const expiresAtSec = activeMembership?.expiresAt?.seconds ?? (profile as any)?.expiresAt?.seconds;
+            type TS = { seconds?: number } | undefined;
+            const profileExpires = (profile as unknown as { expiresAt?: TS })?.expiresAt?.seconds;
+            const expiresAtSec = activeMembership?.expiresAt?.seconds ?? profileExpires;
             const hasActive = typeof expiresAtSec === 'number' && expiresAtSec * 1000 > Date.now();
             const validUntil = typeof expiresAtSec === 'number' ? new Date(expiresAtSec * 1000).toLocaleDateString() : '—';
             const status = hasActive ? 'active' : (typeof expiresAtSec === 'number' ? 'expired' : 'none');

--- a/functions/firestore-debug.log
+++ b/functions/firestore-debug.log
@@ -1,4 +1,4 @@
-Sep 08, 2025 10:15:45 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
+Sep 08, 2025 10:22:21 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
 INFO: Started WebSocket server on ws://127.0.0.1:9150
 API endpoint: http://127.0.0.1:8085
 If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:
@@ -12,179 +12,227 @@ If you are running a Firestore in Datastore Mode project, run:
 Note: Support for Datastore Mode is in preview. If you encounter any bugs please file at https://github.com/firebase/firebase-tools/issues.
 Dev App Server is now running.
 
-Sep 08, 2025 10:15:48 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+Sep 08, 2025 10:22:25 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
 INFO: Connected to new websocket client
-Sep 08, 2025 10:15:50 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+Sep 08, 2025 10:22:28 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
 INFO: Websocket client disconnected
-Sep 08, 2025 10:15:50 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+Sep 08, 2025 10:22:28 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
 INFO: Connected to new websocket client
-Sep 08, 2025 10:16:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:31 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+INFO: Websocket client disconnected
+Sep 08, 2025 10:22:31 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client
+Sep 08, 2025 10:22:35 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:29 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:29 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:16:31 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:31 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:31 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:31 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:31 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:16:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:17:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:22:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:28 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+Sep 08, 2025 10:22:58 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
 INFO: channel closed
-Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:28 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:17:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:17:56 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:07 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:18:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:17 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:23:33 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:33 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:33 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:18:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:33 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:19:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:33 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:19:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:23:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:19:16 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+Sep 08, 2025 10:23:38 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:23:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:42 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:23:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:46 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:46 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:46 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:46 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:58 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:01 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:14 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:14 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:47 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:48 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:24:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:24:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:25:00 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:25:00 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:25:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:25:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:25:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:25:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:25:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:26:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:26:04 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:26:04 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
 INFO: channel closed

--- a/functions/firestore-debug.log
+++ b/functions/firestore-debug.log
@@ -1,4 +1,4 @@
-Sep 08, 2025 10:08:45 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
+Sep 08, 2025 10:15:45 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
 INFO: Started WebSocket server on ws://127.0.0.1:9150
 API endpoint: http://127.0.0.1:8085
 If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:
@@ -12,117 +12,179 @@ If you are running a Firestore in Datastore Mode project, run:
 Note: Support for Datastore Mode is in preview. If you encounter any bugs please file at https://github.com/firebase/firebase-tools/issues.
 Dev App Server is now running.
 
-Sep 08, 2025 10:09:07 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:09:22 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:09:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:10:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:14 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:14 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:10:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:10:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:38 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:11:23 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:11:23 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:11:23 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:11:23 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:11:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:11:36 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:11:51 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:11:51 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:11:51 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:11:51 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:11:51 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:12:02 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:12:56 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+Sep 08, 2025 10:15:48 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
 INFO: Connected to new websocket client
-Sep 08, 2025 10:13:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:13:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:13:03 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:13:10 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+Sep 08, 2025 10:15:50 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
 INFO: Websocket client disconnected
-Sep 08, 2025 10:13:10 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+Sep 08, 2025 10:15:50 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
 INFO: Connected to new websocket client
+Sep 08, 2025 10:16:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected HTTP/2 connection.
+Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:29 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:29 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:16:31 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:31 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:31 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:31 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:31 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:16:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected HTTP/2 connection.
+Sep 08, 2025 10:17:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:28 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:28 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:17:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:17:56 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected HTTP/2 connection.
+Sep 08, 2025 10:18:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:18:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:19:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:19:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:19:16 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed

--- a/functions/firestore-debug.log
+++ b/functions/firestore-debug.log
@@ -1,4 +1,4 @@
-Sep 08, 2025 10:22:21 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
+Sep 08, 2025 10:29:12 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
 INFO: Started WebSocket server on ws://127.0.0.1:9150
 API endpoint: http://127.0.0.1:8085
 If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:
@@ -12,227 +12,81 @@ If you are running a Firestore in Datastore Mode project, run:
 Note: Support for Datastore Mode is in preview. If you encounter any bugs please file at https://github.com/firebase/firebase-tools/issues.
 Dev App Server is now running.
 
-Sep 08, 2025 10:22:25 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Sep 08, 2025 10:22:28 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
-INFO: Websocket client disconnected
-Sep 08, 2025 10:22:28 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Sep 08, 2025 10:22:31 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
-INFO: Websocket client disconnected
-Sep 08, 2025 10:22:31 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Sep 08, 2025 10:22:35 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:22:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:25 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client
+Sep 08, 2025 10:29:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:52 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:29:57 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:22:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:30:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:22:58 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+Sep 08, 2025 10:30:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:30:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:30:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:30:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:30:18 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
 INFO: channel closed
-Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:30:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:30:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:30:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:30:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:30:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:31:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:31:22 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:07 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:23:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:12 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:17 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:23:33 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:33 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:33 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:33 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:33 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:38 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:23:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:41 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:42 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:23:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:46 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:46 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:46 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:46 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:58 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:23:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:01 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:01 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:14 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:14 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:47 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:48 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:24:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:24:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:25:00 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:25:00 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:25:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:25:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:25:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:25:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:25:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:26:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:26:04 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:26:04 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+Sep 08, 2025 10:31:22 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
 INFO: channel closed

--- a/functions/firestore-debug.log
+++ b/functions/firestore-debug.log
@@ -80,3 +80,21 @@ Sep 08, 2025 10:46:36 PM com.google.cloud.datastore.emulator.firestore.websocket
 INFO: Connected to new websocket client
 Sep 08, 2025 10:46:47 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:47:47 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:48:15 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:48:15 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:48:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:48:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:48:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:48:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:48:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:48:53 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.

--- a/functions/firestore-debug.log
+++ b/functions/firestore-debug.log
@@ -1,4 +1,4 @@
-Sep 08, 2025 10:34:39 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
+Sep 08, 2025 10:45:19 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
 INFO: Started WebSocket server on ws://127.0.0.1:9150
 API endpoint: http://127.0.0.1:8085
 If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:
@@ -12,125 +12,71 @@ If you are running a Firestore in Datastore Mode project, run:
 Note: Support for Datastore Mode is in preview. If you encounter any bugs please file at https://github.com/firebase/firebase-tools/issues.
 Dev App Server is now running.
 
-Sep 08, 2025 10:34:54 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:25 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client
+Sep 08, 2025 10:45:25 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:34:57 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:35:09 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Sep 08, 2025 10:35:09 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Sep 08, 2025 10:35:09 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:45:48 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:46:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:46:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:46:36 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
 INFO: Websocket client disconnected
-Sep 08, 2025 10:35:14 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
-INFO: Websocket client disconnected
-Sep 08, 2025 10:35:14 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+Sep 08, 2025 10:46:36 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
 INFO: Connected to new websocket client
-Sep 08, 2025 10:36:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:46:47 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:06 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:36:13 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:13 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:13 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:16 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:36:20 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:20 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:20 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:20 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:20 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:24 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:24 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:24 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:24 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:24 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:36:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:36:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:37:13 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:37:44 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:37:44 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed

--- a/functions/firestore-debug.log
+++ b/functions/firestore-debug.log
@@ -1,4 +1,4 @@
-Sep 08, 2025 9:27:02 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
+Sep 08, 2025 10:08:45 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
 INFO: Started WebSocket server on ws://127.0.0.1:9150
 API endpoint: http://127.0.0.1:8085
 If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:
@@ -12,7 +12,117 @@ If you are running a Firestore in Datastore Mode project, run:
 Note: Support for Datastore Mode is in preview. If you encounter any bugs please file at https://github.com/firebase/firebase-tools/issues.
 Dev App Server is now running.
 
-Sep 08, 2025 9:27:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:09:07 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected HTTP/2 connection.
-*** shutting down gRPC server since JVM is shutting down
-*** server shut down
+Sep 08, 2025 10:09:22 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected HTTP/2 connection.
+Sep 08, 2025 10:09:30 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected HTTP/2 connection.
+Sep 08, 2025 10:10:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:11 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:14 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:14 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:10:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected HTTP/2 connection.
+Sep 08, 2025 10:10:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:34 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:38 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:10:38 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:11:23 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:11:23 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:11:23 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:11:23 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:11:36 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:11:36 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:11:51 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:11:51 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:11:51 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:11:51 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:11:51 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:12:02 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:12:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:12:56 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client
+Sep 08, 2025 10:13:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:13:03 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:13:03 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:13:10 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+INFO: Websocket client disconnected
+Sep 08, 2025 10:13:10 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client

--- a/functions/firestore-debug.log
+++ b/functions/firestore-debug.log
@@ -1,4 +1,4 @@
-Sep 08, 2025 10:45:19 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
+Sep 08, 2025 10:56:34 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
 INFO: Started WebSocket server on ws://127.0.0.1:9150
 API endpoint: http://127.0.0.1:8085
 If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:
@@ -12,89 +12,7 @@ If you are running a Firestore in Datastore Mode project, run:
 Note: Support for Datastore Mode is in preview. If you encounter any bugs please file at https://github.com/firebase/firebase-tools/issues.
 Dev App Server is now running.
 
-Sep 08, 2025 10:45:25 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Sep 08, 2025 10:45:25 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:56:37 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:28 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:48 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:45:48 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:46:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:46:17 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:46:36 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
-INFO: Websocket client disconnected
-Sep 08, 2025 10:46:36 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Sep 08, 2025 10:46:47 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:47:47 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:48:15 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:48:15 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:48:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:48:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:48:40 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:48:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:48:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:48:53 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
+*** shutting down gRPC server since JVM is shutting down
+*** server shut down

--- a/functions/firestore-debug.log
+++ b/functions/firestore-debug.log
@@ -1,4 +1,4 @@
-Sep 08, 2025 10:29:12 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
+Sep 08, 2025 10:34:39 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
 INFO: Started WebSocket server on ws://127.0.0.1:9150
 API endpoint: http://127.0.0.1:8085
 If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:
@@ -12,81 +12,125 @@ If you are running a Firestore in Datastore Mode project, run:
 Note: Support for Datastore Mode is in preview. If you encounter any bugs please file at https://github.com/firebase/firebase-tools/issues.
 Dev App Server is now running.
 
-Sep 08, 2025 10:29:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:34:54 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:29:25 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+Sep 08, 2025 10:34:57 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:34:58 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:02 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:35:09 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
 INFO: Connected to new websocket client
-Sep 08, 2025 10:29:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:35:09 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client
+Sep 08, 2025 10:35:09 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+INFO: Websocket client disconnected
+Sep 08, 2025 10:35:14 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+INFO: Websocket client disconnected
+Sep 08, 2025 10:35:14 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client
+Sep 08, 2025 10:36:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:06 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:42 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:45 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:52 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+Sep 08, 2025 10:36:06 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
 INFO: channel closed
-Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:13 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:13 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:13 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:16 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:16 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:36:20 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:20 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:52 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:20 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:29:57 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:20 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:20 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:24 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:24 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:24 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:24 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:24 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+INFO: channel closed
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:27 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+INFO: Detected non-HTTP/2 connection.
+Sep 08, 2025 10:36:39 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected HTTP/2 connection.
-Sep 08, 2025 10:30:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:30:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:30:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:30:10 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:36:43 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:30:18 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:37:13 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:30:18 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
-INFO: channel closed
-Sep 08, 2025 10:30:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
+Sep 08, 2025 10:37:44 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
 INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:30:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:30:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:30:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:30:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:31:21 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:31:22 PM io.gapi.emulators.netty.HttpVersionRoutingHandler channelRead
-INFO: Detected non-HTTP/2 connection.
-Sep 08, 2025 10:31:22 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
+Sep 08, 2025 10:37:44 PM com.google.cloud.datastore.emulator.firestore.webchannel.FirestoreV1WebChannelAdapter$FirestoreListenHandler onClose
 INFO: channel closed

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -33,12 +33,13 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.dailyRenewalReminders = exports.stripeWebhook = exports.verifyMembership = exports.clearDatabase = exports.getUserClaims = exports.agentCreateMember = exports.searchUserByEmail = exports.startMembership = exports.setUserRole = exports.upsertProfile = exports.exportMembersCsv = void 0;
+exports.dailyRenewalReminders = exports.stripeWebhook = exports.verifyMembership = exports.clearDatabase = exports.importMembersCsv = exports.getUserClaims = exports.agentCreateMember = exports.searchUserByEmail = exports.startMembership = exports.setUserRole = exports.upsertProfile = exports.exportMembersCsv = void 0;
 const functions = __importStar(require("firebase-functions/v1"));
 const firestore_1 = require("firebase-admin/firestore");
 const firebaseAdmin_1 = require("./firebaseAdmin");
 const upsertProfile_1 = require("./lib/upsertProfile");
 const user_1 = require("./lib/user");
+const importCsv_1 = require("./lib/importCsv");
 const startMembership_1 = require("./lib/startMembership");
 const agent_1 = require("./lib/agent");
 const membership_1 = require("./lib/membership");
@@ -65,6 +66,9 @@ exports.agentCreateMember = functions
 exports.getUserClaims = functions
     .region(REGION)
     .https.onCall((data, context) => (0, user_1.getUserClaimsLogic)(data, context));
+exports.importMembersCsv = functions
+    .region(REGION)
+    .https.onCall((data, context) => (0, importCsv_1.importMembersCsvLogic)(data, context));
 // HTTP utilities -------------------------------------------------------------
 exports.clearDatabase = functions
     .region(REGION)

--- a/functions/lib/index.js
+++ b/functions/lib/index.js
@@ -33,13 +33,14 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.dailyRenewalReminders = exports.stripeWebhook = exports.verifyMembership = exports.clearDatabase = exports.importMembersCsv = exports.getUserClaims = exports.agentCreateMember = exports.searchUserByEmail = exports.startMembership = exports.setUserRole = exports.upsertProfile = exports.exportMembersCsv = void 0;
+exports.dailyRenewalReminders = exports.stripeWebhook = exports.verifyMembership = exports.clearDatabase = exports.backfillNameLower = exports.importMembersCsv = exports.getUserClaims = exports.agentCreateMember = exports.searchUserByEmail = exports.startMembership = exports.setUserRole = exports.upsertProfile = exports.exportMembersCsv = void 0;
 const functions = __importStar(require("firebase-functions/v1"));
 const firestore_1 = require("firebase-admin/firestore");
 const firebaseAdmin_1 = require("./firebaseAdmin");
 const upsertProfile_1 = require("./lib/upsertProfile");
 const user_1 = require("./lib/user");
 const importCsv_1 = require("./lib/importCsv");
+const backfill_1 = require("./lib/backfill");
 const startMembership_1 = require("./lib/startMembership");
 const agent_1 = require("./lib/agent");
 const membership_1 = require("./lib/membership");
@@ -69,6 +70,9 @@ exports.getUserClaims = functions
 exports.importMembersCsv = functions
     .region(REGION)
     .https.onCall((data, context) => (0, importCsv_1.importMembersCsvLogic)(data, context));
+exports.backfillNameLower = functions
+    .region(REGION)
+    .https.onCall((data, context) => (0, backfill_1.backfillNameLowerLogic)(data, context));
 // HTTP utilities -------------------------------------------------------------
 exports.clearDatabase = functions
     .region(REGION)

--- a/functions/lib/lib/startMembership.js
+++ b/functions/lib/lib/startMembership.js
@@ -8,8 +8,8 @@ const validators_1 = require("./validators");
 const rbac_1 = require("./rbac");
 const membership_1 = require("./membership");
 async function activateMembership(uid, year, price, currency, paymentMethod, externalRef) {
-    const startsAt = firebaseAdmin_1.admin.firestore.Timestamp.fromDate(new Date(year, 0, 1));
-    const expiresAt = firebaseAdmin_1.admin.firestore.Timestamp.fromDate(new Date(year, 11, 31, 23, 59, 59));
+    const startsAt = firestore_1.Timestamp.fromDate(new Date(year, 0, 1));
+    const expiresAt = firestore_1.Timestamp.fromDate(new Date(year, 11, 31, 23, 59, 59));
     const ref = firebaseAdmin_1.db.collection('members').doc(uid).collection('memberships').doc(String(year));
     let alreadyActive = false;
     await firebaseAdmin_1.db.runTransaction(async (tx) => {

--- a/functions/lib/lib/upsertProfile.js
+++ b/functions/lib/lib/upsertProfile.js
@@ -80,6 +80,7 @@ async function upsertProfileLogic(data, context) {
             await (0, unique_1.reserveUniqueEmail)(auth.uid, emailLower, tx);
             tx.set(memberRef, {
                 ...validatedData,
+                nameLower: String(validatedData.name || '').toLowerCase().trim(),
                 email: emailLower,
                 memberNo,
                 updatedAt: nowTs,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,6 +3,7 @@ import { Timestamp, FieldValue } from 'firebase-admin/firestore';
 import { admin, db } from "./firebaseAdmin";
 import { upsertProfileLogic } from "./lib/upsertProfile";
 import { setUserRoleLogic, searchUserByEmailLogic, getUserClaimsLogic } from "./lib/user";
+import { importMembersCsvLogic } from './lib/importCsv';
 import { startMembershipLogic } from "./lib/startMembership";
 import { agentCreateMemberLogic } from "./lib/agent";
 import { sendRenewalReminder } from "./lib/membership";
@@ -35,6 +36,10 @@ export const agentCreateMember = functions
 export const getUserClaims = functions
   .region(REGION)
   .https.onCall((data, context) => getUserClaimsLogic(data, context));
+
+export const importMembersCsv = functions
+  .region(REGION)
+  .https.onCall((data, context) => importMembersCsvLogic(data, context));
 
 // HTTP utilities -------------------------------------------------------------
 export const clearDatabase = functions

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,6 +4,7 @@ import { admin, db } from "./firebaseAdmin";
 import { upsertProfileLogic } from "./lib/upsertProfile";
 import { setUserRoleLogic, searchUserByEmailLogic, getUserClaimsLogic } from "./lib/user";
 import { importMembersCsvLogic } from './lib/importCsv';
+import { backfillNameLowerLogic } from './lib/backfill';
 import { startMembershipLogic } from "./lib/startMembership";
 import { agentCreateMemberLogic } from "./lib/agent";
 import { sendRenewalReminder } from "./lib/membership";
@@ -40,6 +41,10 @@ export const getUserClaims = functions
 export const importMembersCsv = functions
   .region(REGION)
   .https.onCall((data, context) => importMembersCsvLogic(data, context));
+
+export const backfillNameLower = functions
+  .region(REGION)
+  .https.onCall((data, context) => backfillNameLowerLogic(data, context));
 
 // HTTP utilities -------------------------------------------------------------
 export const clearDatabase = functions

--- a/functions/src/lib/agent.ts
+++ b/functions/src/lib/agent.ts
@@ -92,6 +92,7 @@ export async function agentCreateMemberLogic(data: any, context: functions.https
     tx.set(memberRef, {
       email: emailLower,
       name: input.name,
+      nameLower: input.name.toLowerCase().trim(),
       region: input.region,
       phone: input.phone,
       orgId: input.orgId,

--- a/functions/src/lib/startMembership.ts
+++ b/functions/src/lib/startMembership.ts
@@ -1,5 +1,5 @@
 import { admin, db } from "../firebaseAdmin";
-import { FieldValue } from 'firebase-admin/firestore';
+import { FieldValue, Timestamp } from 'firebase-admin/firestore';
 import * as functions from "firebase-functions/v1";
 import { startMembershipSchema } from "./validators";
 import { requireAdmin } from "./rbac";
@@ -13,8 +13,8 @@ export async function activateMembership(
   paymentMethod: string,
   externalRef: string | null | undefined
 ): Promise<{ refPath: string; alreadyActive: boolean }> {
-  const startsAt = admin.firestore.Timestamp.fromDate(new Date(year, 0, 1));
-  const expiresAt = admin.firestore.Timestamp.fromDate(new Date(year, 11, 31, 23, 59, 59));
+  const startsAt = Timestamp.fromDate(new Date(year, 0, 1));
+  const expiresAt = Timestamp.fromDate(new Date(year, 11, 31, 23, 59, 59));
 
   const ref = db.collection('members').doc(uid).collection('memberships').doc(String(year));
 

--- a/functions/src/lib/upsertProfile.ts
+++ b/functions/src/lib/upsertProfile.ts
@@ -53,6 +53,7 @@ export async function upsertProfileLogic(data: any, context: functions.https.Cal
 
       tx.set(memberRef, {
         ...validatedData,
+        nameLower: String(validatedData.name || '').toLowerCase().trim(),
         email: emailLower,
         memberNo,
         updatedAt: nowTs,


### PR DESCRIPTION
feat(admin): members list pagination + region filter; fix rewrites to europe-west1; re‑enable admin activate E2E

Summary
- Adds cursor-based pagination and a region filter to the Admin Members list.
- Fixes Firebase Hosting rewrites to call europe-west1 HTTP functions.
- Stabilizes and re-enables the Admin Activate E2E by verifying backend state only.

Changes
- Admin UI
  - Region filter dropdown and Prev/Next controls above the members table.
  - List respects `allowedRegions` and explicit region filter.
  - Page size set to 25; ordered by `createdAt` desc for stable pagination.
  - Files: `frontend/src/pages/Admin.tsx`, `frontend/src/hooks/useUsers.ts`
- Firebase Hosting
  - Hosting rewrites now explicitly route to europe-west1 for:
    - `/verifyMembership`, `/stripeWebhook`, `/exportMembersCsv`
  - File: `firebase.json`
- E2E tests
  - Re-enabled admin activate spec; removed flaky HTTP status intercepts.
  - Verifies membership activation by polling `/verifyMembership?memberNo=...` through Hosting.
  - File: `cypress/e2e/admin_activate.cy.ts`
- Docs
  - Marked Phase 0 items as done in `docs/NEXT_TASKS.md`
  - Appended dated session snapshot to `docs/STATE_SNAPSHOT_2025-09-08.md`

Testing
- Local unit/CI:
  - Frontend: `cd frontend && npm test && npm run lint && npm run build`
  - Functions: `cd functions && npm run build && npm test && npm run lint`
  - Rules: `npm test` (root)
- E2E (all green):
  - Start emulators: `cd functions && npm run serve`
  - Run Cypress: `npm run cypress:run`
  - Verified specs pass including `admin_activate.cy.ts`

Emulator steps to reproduce
1) Start emulators: `cd functions && npm run serve`
2) Seed demo data (automatically done in specs; manual: `curl -X POST http://localhost:5001/demo-interdomestik/europe-west1/seedDatabase`)
3) Visit Hosting at `http://localhost:5000`; navigate to Admin to see region filter and pagination in the list.
4) Hit `/verifyMembership?memberNo=<value>` to confirm Hosting → europe-west1 routing works.

Implementation notes
- Query ordering: `orderBy('createdAt', 'desc')` to ensure stable cursors.
- Region filtering:
  - If a specific region is selected: `where('region', '==', <region>)`
  - Else respects viewer’s `allowedRegions` via `where('region', 'in', [...])` (limited to 10).
- Indexes: `firestore.indexes.json` already includes `members` composite on `region ASC, createdAt DESC`.

Known limitations
- Prev navigation uses a simple cursor stack and may need refinement (e.g., `endBefore`/`limitToLast`) for perfect back navigation across many pages. Can iterate later.

Checklist
- [x] Frontend unit tests pass
- [x] Functions build/tests pass
- [x] Rules tests pass
- [x] Cypress E2E pass locally against emulators
- [x] Docs updated (NEXT_TASKS, session snapshot)
- [x] Conventional Commits
